### PR TITLE
Feature/#110#111 automate the ci pipeline for central services auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,10 +86,10 @@ workflows:
                 - /feature*/
                 - /bugfix*/
       - deploy:
-        requires:
-          - setup
-          - test-unit
-          - test-coverage
+          requires:
+            - setup
+            - test-unit
+            - test-coverage
         # filters:
         #     tags:
         #       only: /v[0-9]+(\.[0-9]+)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,15 +51,15 @@ jobs:
           path: coverage
   deploy:
     <<: *defaults
-    # environment:
-    #   - NPM_TOKEN: {{ .Environment.NPM_TOKEN }}
+    environment:
+      - NPM_TOKEN: {{ .Environment.NPM_TOKEN }}
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Update NPM registry auth token
-          command: echo "//registry.npmjs.org/:_authToken={{ .Environment.NPM_TOKEN}}" > .npmrc
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run: 
           name: Publish NPM artifact
           command: npm publish --access public

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Update NPM registry auth token
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          command: echo "//registry.npmjs.org/:_authToken={{ .Environment.NPM_TOKEN }}" > .npmrc
       - run: 
           name: Publish NPM artifact
           command: npm publish --access public

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,9 +92,7 @@ workflows:
                 - /feature*/
                 - /bugfix*/
       - deploy:
-          context: 
-            - org-global
-            - org-global-npm
+          context: org-global
           requires:
             - setup
             - test-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           path: coverage
           prefix: test
       - store_test_results:
-          path: coverage/coverage.json
+          path: coverage
   deploy:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,8 +51,8 @@ jobs:
           path: coverage
   deploy:
     <<: *defaults
-    environment:
-      - NPM_TOKEN: "TEST"
+    # environment:
+    #   - NPM_TOKEN: "TEST"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,14 +45,12 @@ jobs:
           name: Execute code coverage check
           command: npm -s run test:coverage-check
       - store_artifacts:
-          path: coverage/lcov-report
+          path: coverage
           prefix: test
       - store_test_results:
-          path: coverage/lcov-report
+          path: coverage/lcov-report/index.html
   deploy:
     <<: *defaults
-    # environment:
-    #   - NPM_TOKEN: "TEST"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,9 +65,9 @@ workflows:
   build_and_test:
     jobs:
       - setup:
-        filters:
-            branches:
-              ignore: /feature*/
+          filters:
+              branches:
+                ignore: /feature*/
       # - test-unit:
       #   requires:
       #     - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,25 +61,19 @@ workflows:
       - setup:
         filters:
             branches:
-              ignore:
-                - /bugfix*/
-                # - /feature*/
+              ignore: /feature*/
       - test-unit:
         requires:
           - setup
         filters:
           branches:
-            ignore:
-              - /bugfix*/
-              # - /feature*/      
+            ignore: /feature*/    
       - test-coverage:
         requires:
           - setup
         filters:
           branches:
-            ignore:
-              - /bugfix*/
-              # - /feature*/
+            ignore: /feature*/
       - build:
         requires:
           - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
     <<: *defaults
     steps:
       - attach_workspace:
-          at: /home/circleci
+          at: .
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: mkdir -p ./test/results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
             branches:
               ignore:
                 - /bugfix*/
-                - /feature*/
+                # - /feature*/
       - test-unit:
         requires:
           - setup
@@ -70,7 +70,7 @@ workflows:
           branches:
             ignore:
               - /bugfix*/
-              - /feature*/          
+              # - /feature*/      
       - test-coverage:
         requires:
           - setup
@@ -78,7 +78,7 @@ workflows:
           branches:
             ignore:
               - /bugfix*/
-              - /feature*/
+              # - /feature*/
       - build:
         requires:
           - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,13 +51,15 @@ jobs:
           path: coverage
   deploy:
     <<: *defaults
+    environment:
+      - NPM_TOKEN: {{ .Environment.NPM_TOKEN }}
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Update NPM registry auth token
-          command: echo "//registry.npmjs.org/:_authToken={{ .Environment.NPM_TOKEN }}" > .npmrc
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
       - run: 
           name: Publish NPM artifact
           command: npm publish --access public

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Update NPM registry auth token
-          command: echo "//registry.npmjs.org/:_authToken=$(eval echo ${NPM_TOKEN})" > .npmrc
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
       - run: 
           name: Publish NPM artifact
           command: npm publish --access public

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
       - run:
           name: Copy code coverage to SonarQube
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ];
+            if [ "${CIRCLE_BRANCH}" == "develop-test" ];
             then
                 echo "Sending lcov.info to SonarQube..."  
                 aws s3 cp coverage/lcov.info $AWS_S3_DIR_SONARQUBE/central-services-auth/lcov.info

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,25 +62,27 @@ workflows:
         filters:
             branches:
               ignore: /feature*/
-      - test-unit:
-        requires:
-          - setup
-        filters:
-          branches:
-            ignore: /feature*/    
-      - test-coverage:
-        requires:
-          - setup
-        filters:
-          branches:
-            ignore: /feature*/
-      - build:
-        requires:
-          - setup
-          - test-unit
-          - test-coverage
-        filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
-            branches:
-              only: /feature*/
+      # - test-unit:
+      #   requires:
+      #     - setup
+      #   filters:
+      #     branches:
+      #       ignore: /feature*/    
+      # - test-coverage:
+      #   requires:
+      #     - setup
+      #   filters:
+      #     branches:
+      #       ignore: /feature*/
+      # - build:
+      #   requires:
+      #     - setup
+      #     - test-unit
+      #     - test-coverage
+      #   filters:
+      #       tags:
+      #         only: /v[0-9]+(\.[0-9]+)*/
+      #       branches:
+      #         only: 
+      #           - master
+      #           - develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,91 @@
+version: 2
+jobs:
+  setup:
+    docker:
+      - image: circleci/node:$NODE_VERSION
+    steps:
+      - run:
+          name: update-npm
+          command: 'sudo npm install -g npm@latest'
+      - save_cache:
+        key: dependency-cache-{{ checksum "package.json" }}
+        paths:
+          - ./node_modules
+  test-unit:
+    docker:
+      - image: circleci/node:$NODE_VERSION
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: mkdir -p ./test/results
+      - run: npm -s run test:xunit > ./test/results/tape.xml
+      - store_artifacts:
+          path: ./test/results/tape.xml
+          prefix: test
+      - store_test_results:
+          path: ./test/results/tape.xml
+  test-coverage:
+    docker:
+      - image: circleci/node:$NODE_VERSION
+    steps:
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      - run: npm -s run test:coverage-check
+      - store_artifacts:
+          path: coverage
+          prefix: test
+      - store_test_results:
+          path: coverage
+  deploy:
+    docker:
+      - image: circleci/node:$NODE_VERSION
+    steps:
+      - checkout
+      # restore npm module dependencies from cache
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      # setup npm
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+      # publish npm
+      - deploy:
+        name: publish-npm
+        command: npm publish --access public
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - setup:
+        filters:
+            branches:
+              ignore:
+                - /bugfix*/
+                # - /feature*/
+      - test-unit:
+        requires:
+          - setup
+        filters:
+          branches:
+            ignore:
+              - /bugfix*/
+              # - /feature*/          
+      - test-coverage:
+        requires:
+          - setup
+        filters:
+          branches:
+            ignore:
+              - /bugfix*/
+              # - /feature*/
+      - deploy
+        requires:
+          - setup
+          - test-unit
+          - test-coverage
+        filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              only: /feature*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Update NPM registry auth token
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          command: echo "//registry.npmjs.org/:_authToken=$(eval echo ${NPM_TOKEN})" > .npmrc
       - run: 
           name: Publish NPM artifact
           command: npm publish --access public

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI Config 2017 test
+# CircleCI v2 Config
 version: 2
 
 defaults: &defaults
@@ -51,8 +51,8 @@ jobs:
           path: coverage
   deploy:
     <<: *defaults
-    environment:
-      - NPM_TOKEN: {{ .Environment.NPM_TOKEN }}
+    # environment:
+    #   - NPM_TOKEN: {{ .Environment.NPM_TOKEN }}
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           prefix: test
       - store_test_results:
           path: coverage
-  deploy:
+  build:
     docker:
       - image: circleci/node:$NODE_VERSION
     steps:
@@ -80,6 +80,7 @@ workflows:
               - /bugfix*/
               # - /feature*/
       - deploy
+      - build:
         requires:
           - setup
           - test-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,12 +51,25 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
+      - run: mkdir -p ./test/results
       - run: npm -s run test:coverage-check
       - store_artifacts:
           path: coverage
           prefix: test
       - store_test_results:
           path: coverage
+  # test-coverage:
+  #   <<: *defaults
+  #   steps:
+  #     - checkout
+  #     - restore_cache:
+  #         key: dependency-cache-{{ checksum "package.json" }}
+  #     - run: npm -s run test:coverage-check
+  #     - store_artifacts:
+  #         path: coverage
+  #         prefix: test
+  #     - store_test_results:
+  #         path: coverage
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,4 @@
+# CircleCI Config
 version: 2
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - run:
           name: update-npm
-          command: 'sudo npm install -g npm@latest'
+          command: 'sudo npm install'
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:${NODE_VERSION}
+      - image: circleci/node:6.10.3
     steps:
       - checkout
       # restore npm module dependencies from cache
@@ -17,7 +17,7 @@ jobs:
         command: npm publish --access public
   setup:
     docker:
-      - image: circleci/node:${NODE_VERSION}
+      - image: circleci/node:6.10.3
     steps:
       - run:
           name: update-npm
@@ -28,7 +28,7 @@ jobs:
             - node_modules
   test-unit:
     docker:
-      - image: circleci/node:${NODE_VERSION}
+      - image: circleci/node:6.10.3
     steps:
       - checkout
       - restore_cache:
@@ -42,7 +42,7 @@ jobs:
           path: ./test/results/tape.xml
   test-coverage:
     docker:
-      - image: circleci/node:${NODE_VERSION}
+      - image: circleci/node:6.10.3
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Update NPM registry auth token
-          command: echo "//registry.npmjs.org/:_authToken=$(eval echo ${NMP_TOKEN})" > .npmrc
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
       - run: 
           name: Publish NPM artifact
           command: npm publish --access public

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI Config 2017
+# CircleCI Config 2017 ds
 version: 2
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
-# CircleCI Config 2017
+# CircleCI Config 2017 test
 version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:$NODE_VERSION
+      - image: circleci/node:${NODE_VERSION}
     steps:
       - checkout
       # restore npm module dependencies from cache
@@ -17,7 +17,7 @@ jobs:
         command: npm publish --access public
   setup:
     docker:
-      - image: circleci/node:$NODE_VERSION
+      - image: circleci/node:${NODE_VERSION}
     steps:
       - run:
           name: update-npm
@@ -28,7 +28,7 @@ jobs:
             - node_modules
   test-unit:
     docker:
-      - image: circleci/node:$NODE_VERSION
+      - image: circleci/node:${NODE_VERSION}
     steps:
       - checkout
       - restore_cache:
@@ -42,7 +42,7 @@ jobs:
           path: ./test/results/tape.xml
   test-coverage:
     docker:
-      - image: circleci/node:$NODE_VERSION
+      - image: circleci/node:${NODE_VERSION}
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,14 +70,14 @@ workflows:
                 ignore: 
                   - /feature*/
                   - /bugfix*/
-      # - test-unit:
-      #     requires:
-      #       - setup
-      #     filters:
-      #       branches:
-      #         ignore: 
-      #           - /feature*/
-      #           - /bugfix*/             
+      - test-unit:
+          requires:
+            - setup
+          filters:
+            branches:
+              ignore: 
+                - /feature*/
+                - /bugfix*/             
       # - test-coverage:
       #     requires:
       #       - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           path: coverage
           prefix: test
       - store_test_results:
-          path: coverage/lcov-report/index.html
+          path: coverage/coverage.json
   deploy:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Update NPM registry auth token
-          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+          command: echo "//registry.npmjs.org/:_authToken=$(eval echo ${NMP_TOKEN})" > .npmrc
       - run: 
           name: Publish NPM artifact
           command: npm publish --access public

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,21 +70,21 @@ workflows:
                 ignore: 
                   - /feature*/
                   - /bugfix*/
-      - test-unit:
-          requires:
-            - setup
-          filters:
-            branches:
-              ignore: 
-                - /feature*/
-                - /bugfix*/             
-      - test-coverage:
-          requires:
-            - setup
-          filters:
-            branches:
-                - /feature*/
-                - /bugfix*/
+      # - test-unit:
+      #     requires:
+      #       - setup
+      #     filters:
+      #       branches:
+      #         ignore: 
+      #           - /feature*/
+      #           - /bugfix*/             
+      # - test-coverage:
+      #     requires:
+      #       - setup
+      #     filters:
+      #       branches:
+      #           - /feature*/
+      #           - /bugfix*/
       # - build:
       #   requires:
       #     - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Update NPM registry auth token
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+          command: echo "//registry.npmjs.org/:_authToken={{ .Environment.NPM_TOKEN}}" > .npmrc
       - run: 
           name: Publish NPM artifact
           command: npm publish --access public

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,17 +41,16 @@ jobs:
       - run: mkdir -p ./test/results
       - run: npm -s run test:xunit > ./test/results/tape.xml
       - store_artifacts:
-          path: ./test/results/tape.xml
+          path: ./test/results/
           prefix: test
       - store_test_results:
-          path: ./test/results/tape.xml
+          path: ./test/results/
   test-coverage:
     <<: *defaults
     steps:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: ls -l
       - run: npm -s run test:coverage-check
       - store_artifacts:
           path: coverage
@@ -77,13 +76,13 @@ workflows:
               ignore: 
                 - /feature*/
                 - /bugfix*/             
-      # - test-coverage:
-      #     requires:
-      #       - setup
-      #     filters:
-      #       branches:
-      #           - /feature*/
-      #           - /bugfix*/
+      - test-coverage:
+          requires:
+            - setup
+          filters:
+            branches:
+                - /feature*/
+                - /bugfix*/
       # - build:
       #   requires:
       #     - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,11 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: mkdir -p ./test/results
       - run: npm -s run test:coverage-check
-      - store_artifacts:
-          path: coverage
-          prefix: test
-      - store_test_results:
-          path: coverage
+      # - store_artifacts:
+      #     path: coverage
+      #     prefix: test
+      # - store_test_results:
+      #     path: coverage
   # test-coverage:
   #   <<: *defaults
   #   steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,18 +70,21 @@ workflows:
                 ignore: 
                   - /feature*/
                   - /bugfix*/
-      # - test-unit:
-      #   requires:
-      #     - setup
-      #   filters:
-      #     branches:
-      #       ignore: /feature*/    
-      # - test-coverage:
-      #   requires:
-      #     - setup
-      #   filters:
-      #     branches:
-      #       ignore: /feature*/
+      - test-unit:
+          requires:
+            - setup
+          filters:
+            branches:
+              ignore: 
+                - /feature*/
+                - /bugfix*/             
+      - test-coverage:
+          requires:
+            - setup
+          filters:
+            branches:
+                - /feature*/
+                - /bugfix*/
       # - build:
       #   requires:
       #     - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,9 @@ jobs:
           name: update-npm
           command: 'sudo npm install -g npm@latest'
       - save_cache:
-        key: dependency-cache-{{ checksum "package.json" }}
-        paths:
-          - node_modules
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - node_modules
   test-unit:
     docker:
       - image: circleci/node:$NODE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,19 @@
 version: 2
 jobs:
+  build:
+    docker:
+      - image: circleci/node:$NODE_VERSION
+    steps:
+      - checkout
+      # restore npm module dependencies from cache
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      # setup npm
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+      # publish npm
+      - deploy:
+        name: publish-npm
+        command: npm publish --access public
   setup:
     docker:
       - image: circleci/node:$NODE_VERSION
@@ -38,20 +52,6 @@ jobs:
           prefix: test
       - store_test_results:
           path: coverage
-  build:
-    docker:
-      - image: circleci/node:$NODE_VERSION
-    steps:
-      - checkout
-      # restore npm module dependencies from cache
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-      # setup npm
-      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-      # publish npm
-      - deploy:
-        name: publish-npm
-        command: npm publish --access public
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,78 @@
 # CircleCI v2 Config
 version: 2
 
-defaults: &defaults
+defaults_working_directory: &defaults_working_directory
   working_directory: /home/circleci/project
+
+defaults_docker_node: &defaults_docker_node
   docker:
-    - image: circleci/node:6.10.3
+    - image: mhart/alpine-node:8.9.4
+
+defaults_Dependencies: &defaults_Dependencies | 
+    apk --no-cache add git
+    apk --no-cache add ca-certificates
+    apk --no-cache add curl
+    apk --no-cache add openssh-client
+
+defaults_awsCliDependencies: &defaults_awsCliDependencies | 
+    apk --no-cache add \
+            python \
+            py-pip \
+            groff \
+            less \
+            mailcap
+    pip install --upgrade awscli==1.14.5 s3cmd==2.0.1 python-magic
+    apk -v --purge del py-pip
+
+defaults_npm_auth: &defaults_npm_auth
+  name: Update NPM registry auth token
+  command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
+
+defaults_npm_publish_version: &defaults_npm_publish
+  name: Update version to prerelease
+  command: |
+    source $BASH_ENV
+    echo "Publishing tag $CIRCLE_TAG"
+    npm publish --tag $CIRCLE_TAG --access public
+
+defaults_npm_publish_release: &defaults_npm_publish_release
+  name: Publish NPM $RELEASE_TAG artifact
+  command: |
+    source $BASH_ENV
+    echo "Publishing tag $RELEASE_TAG"
+    npm publish --tag $RELEASE_TAG --access public
 
 jobs:
   setup:
-    <<: *defaults
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
     steps:
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
       - checkout
       - run:
           name: Update NPM install
-          command: sudo npm install
+          command: npm install
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
+  
   test-unit:
-    <<: *defaults
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
     steps:
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: 
+      - run:
           name: Create dir for test results
           command: mkdir -p ./test/results
-      - run: 
+      - run:
           name: Execute unit tests
           command: npm -s run test:xunit > ./test/results/tape.xml
       - store_artifacts:
@@ -35,13 +80,21 @@ jobs:
           prefix: test
       - store_test_results:
           path: ./test/results
+  
   test-coverage:
-    <<: *defaults
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
     steps:
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - run:
+          name: Install AWS CLI dependencies
+          command: *defaults_awsCliDependencies
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: 
+      - run:
           name: Execute code coverage check
           command: npm -s run test:coverage-check
       - store_artifacts:
@@ -49,18 +102,50 @@ jobs:
           prefix: test
       - store_test_results:
           path: coverage/lcov.info
-  deploy:
-    <<: *defaults
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
       - run:
-          name: Update NPM registry auth token
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc
-      - run: 
-          name: Publish NPM artifact
-          command: npm publish --access public
+          name: Copy code coverage to SonarQube
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ];
+            then
+                echo "Sending lcov.info to SonarQube..."  
+                aws s3 cp coverage/lcov.info $AWS_S3_DIR_SONARQUBE/central-services-auth/lcov.info
+            else
+                echo "Not a release (env CIRCLE_BRANCH != 'master'), skipping sending lcov.info to SonarQube." 
+            fi 
+  
+  build-snapshot:
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
+    steps:
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - checkout
+      - run:
+          name: setup environment vars for SNAPSHOT release
+          command: |
+            echo 'export RELEASE_TAG=$RELEASE_TAG_SNAPSHOT' >> $BASH_ENV
+      - run:
+          <<: *defaults_npm_auth
+      - run:
+          <<: *defaults_npm_publish_release
+  
+  build:
+    <<: *defaults_working_directory
+    <<: *defaults_docker_node
+    steps:
+      - run:
+          name: Install general dependencies
+          command: *defaults_Dependencies
+      - checkout
+      - run:
+          name: setup environment vars for LATEST release
+          command: |
+            echo 'export RELEASE_TAG=$RELEASE_TAG_PROD' >> $BASH_ENV
+      - run:
+          <<: *defaults_npm_auth
+      - run:      
+          <<: *defaults_npm_publish_release
 
 workflows:
   version: 2
@@ -69,29 +154,47 @@ workflows:
       - setup:
           context: org-global
           filters:
-              branches:
-                ignore: 
-                  - /feature*/
-                  - /bugfix*/
+            tags:
+              only: /.*/
+            branches:
+              ignore: 
+                - /feature*/
+                - /bugfix*/
       - test-unit:
           context: org-global
           requires:
             - setup
           filters:
+            tags:
+              only: /.*/
             branches:
               ignore: 
                 - /feature*/
-                - /bugfix*/             
+                - /bugfix*/
       - test-coverage:
           context: org-global
           requires:
             - setup
           filters:
+            tags:
+              only: /.*/
             branches:
               ignore: 
                 - /feature*/
                 - /bugfix*/
-      - deploy:
+      - build-snapshot:
+          context: org-global
+          requires:
+            - setup
+            - test-unit
+            - test-coverage
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*\-snapshot+(\.[0-9]+)/
+            branches:
+              ignore: 
+                - /.*/
+      - build:
           context: org-global
           requires:
             - setup
@@ -101,5 +204,5 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
             branches:
-              only:
-                - master
+              ignore: 
+                - /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,10 @@ jobs:
           name: Execute code coverage check
           command: npm -s run test:coverage-check
       - store_artifacts:
-          path: coverage
+          path: coverage/lcov-report
           prefix: test
       - store_test_results:
-          path: coverage
+          path: coverage/lcov-report
   deploy:
     <<: *defaults
     # environment:
@@ -99,5 +99,5 @@ workflows:
             tags:
               only: /v[0-9]+(\.[0-9]+)*/
             branches:
-              only: 
+              only:
                 - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,9 @@ workflows:
       - setup:
           filters:
               branches:
-                ignore: /feature*/
+                ignore: 
+                  - /feature*/
+                  - /bugfix*/
       # - test-unit:
       #   requires:
       #     - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,9 @@ workflows:
                 - /feature*/
                 - /bugfix*/
       - deploy:
-          context: org-global
+          context: 
+            - org-global
+            - org-global-npm
           requires:
             - setup
             - test-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,11 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - setup:
-        filters:
-            branches:
-              ignore: /feature*/
+      - setup
+      # - setup:
+      #   filters:
+      #       branches:
+      #         ignore: /feature*/
       # - test-unit:
       #   requires:
       #     - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,11 +53,11 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: mkdir -p ./test/results
       - run: npm -s run test:coverage-check
-      # - store_artifacts:
-      #     path: coverage
-      #     prefix: test
-      # - store_test_results:
-      #     path: coverage
+      - store_artifacts:
+          path: coverage
+          prefix: test
+      - store_test_results:
+          path: coverage
   # test-coverage:
   #   <<: *defaults
   #   steps:
@@ -93,7 +93,7 @@ workflows:
           requires:
             - setup
           filters:
-            branches:
+              branches:
                 - /feature*/
                 - /bugfix*/
       # - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI v2 Config
+# CircleCI v2 Config test build
 version: 2
 
 defaults: &defaults
@@ -13,7 +13,7 @@ jobs:
       - checkout
       - run:
           name: Update NPM install
-          command: 'sudo npm install'
+          command: sudo npm install
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI Config
+# CircleCI Config 2017
 version: 2
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
   deploy:
     <<: *defaults
     environment:
-      - NPM_TOKEN: $NPM_TOKEN
+      - NPM_TOKEN: "TEST"
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,10 @@ workflows:
             - setup
             - test-unit
             - test-coverage
-          filters:
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*/
-            branches:
-              only: 
-                - master
-                - develop
+          # filters:
+          #   tags:
+          #     only: /v[0-9]+(\.[0-9]+)*/
+          #   branches:
+          #     only: 
+          #       - master
+          #       - develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,10 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - setup
-      # - setup:
-      #   filters:
-      #       branches:
-      #         ignore: /feature*/
+      - setup:
+        filters:
+            branches:
+              ignore: /feature*/
       # - test-unit:
       #   requires:
       #     - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ workflows:
             branches:
               ignore:
                 - /bugfix*/
-                # - /feature*/
+                - /feature*/
       - test-unit:
         requires:
           - setup
@@ -70,7 +70,7 @@ workflows:
           branches:
             ignore:
               - /bugfix*/
-              # - /feature*/          
+              - /feature*/          
       - test-coverage:
         requires:
           - setup
@@ -78,8 +78,7 @@ workflows:
           branches:
             ignore:
               - /bugfix*/
-              # - /feature*/
-      - deploy
+              - /feature*/
       - build:
         requires:
           - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI Config 2017 ds
+# CircleCI Config 2017
 version: 2
 jobs:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,11 @@
 # CircleCI Config 2017 test
 version: 2
+
+defaults: &defaults
+  working_directory: /home/circleci/project
+  docker:
+    - image: circleci/node:6.10.3
+
 jobs:
   build:
     docker:
@@ -16,9 +22,9 @@ jobs:
         name: publish-npm
         command: npm publish --access public
   setup:
-    docker:
-      - image: circleci/node:6.10.3
+    <<: *defaults
     steps:
+      - checkout
       - run:
           name: update-npm
           command: 'sudo npm install'
@@ -27,10 +33,10 @@ jobs:
           paths:
             - node_modules
   test-unit:
-    docker:
-      - image: circleci/node:6.10.3
+    <<: *defaults
     steps:
-      - checkout
+      - attach_workspace:
+          at: /home/circleci
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: mkdir -p ./test/results
@@ -41,10 +47,10 @@ jobs:
       - store_test_results:
           path: ./test/results/tape.xml
   test-coverage:
-    docker:
-      - image: circleci/node:6.10.3
+    <<: *defaults
     steps:
-      - checkout
+      - attach_workspace:
+          at: /home/circleci
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: npm -s run test:coverage-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: update-npm
+          name: Update NPM install
           command: 'sudo npm install'
       - save_cache:
           key: dependency-cache-{{ checksum "package.json" }}
@@ -24,8 +24,12 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: mkdir -p ./test/results
-      - run: npm -s run test:xunit > ./test/results/tape.xml
+      - run: 
+          name: Create dir for test results
+          command: mkdir -p ./test/results
+      - run: 
+          name: Execute unit tests
+          command: npm -s run test:xunit > ./test/results/tape.xml
       - store_artifacts:
           path: ./test/results
           prefix: test
@@ -37,27 +41,26 @@ jobs:
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      - run: mkdir -p ./test/results
-      - run: npm -s run test:coverage-check
+      - run: 
+          name: Execute code coverage check
+          command: npm -s run test:coverage-check
       - store_artifacts:
           path: coverage
           prefix: test
       - store_test_results:
           path: coverage
   deploy:
-    docker:
-      - image: circleci/node:6.10.3
+    <<: *defaults
     steps:
       - checkout
-      # restore npm module dependencies from cache
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
-      # setup npm
-      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-      # publish npm
-      - deploy:
-        name: publish-npm
-        command: npm publish --access public
+      - run:
+          name: Update NPM registry auth token
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+      - run: 
+          name: Publish NPM artifact
+          command: npm publish --access public
 
 workflows:
   version: 2
@@ -90,10 +93,10 @@ workflows:
             - setup
             - test-unit
             - test-coverage
-        # filters:
-        #     tags:
-        #       only: /v[0-9]+(\.[0-9]+)*/
-        #     branches:
-        #       only: 
-        #         - master
-        #         - develop
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              only: 
+                - master
+                - develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI v2 Config test build
+# CircleCI v2 Config
 version: 2
 
 defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,9 @@ jobs:
     steps:
       - attach_workspace:
           at: /home/circleci
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+      # - restore_cache:
+      #     key: dependency-cache-{{ checksum "package.json" }}
+      - run: ls -l
       - run: npm -s run test:coverage-check
       - store_artifacts:
           path: coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,9 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
+      - persist_to_workspace:
+          paths:
+            - /home/circleci
   test-unit:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
   deploy:
     <<: *defaults
     environment:
-      - NPM_TOKEN: {{ .Environment.NPM_TOKEN }}
+      - NPM_TOKEN: $NPM_TOKEN
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI v2 Config test sd
+# CircleCI v2 Config
 version: 2
 
 defaults: &defaults
@@ -95,10 +95,9 @@ workflows:
             - setup
             - test-unit
             - test-coverage
-          # filters:
-          #   tags:
-          #     only: /v[0-9]+(\.[0-9]+)*/
-          #   branches:
-          #     only: 
-          #       - master
-          #       - develop
+          filters:
+            tags:
+              only: /v[0-9]+(\.[0-9]+)*/
+            branches:
+              only: 
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,9 @@ jobs:
           paths:
             - node_modules
       - persist_to_workspace:
+          root: /
           paths:
-            - /home/circleci
+            - ./home/circleci
   test-unit:
     <<: *defaults
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ workflows:
             - test-coverage
           filters:
             tags:
-              only: /v[0-9]+(\.[0-9]+)*\-snapshot+(\.[0-9]+)/
+              only: /v[0-9]+(\.[0-9]+)*\-snapshot+((\.[0-9]+)?)/
             branches:
               ignore: 
                 - /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI v2 Config
+# CircleCI v2 Config test
 version: 2
 
 defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,8 @@ workflows:
           requires:
             - setup
           filters:
-              branches:
+            branches:
+              ignore: 
                 - /feature*/
                 - /bugfix*/
       # - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,15 +32,10 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
           paths:
             - node_modules
-      - persist_to_workspace:
-          root: /
-          paths:
-            - ./home/circleci
   test-unit:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: .
+      - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run: mkdir -p ./test/results
@@ -53,10 +48,9 @@ jobs:
   test-coverage:
     <<: *defaults
     steps:
-      - attach_workspace:
-          at: /home/circleci
-      # - restore_cache:
-      #     key: dependency-cache-{{ checksum "package.json" }}
+      - checkout
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
       - run: ls -l
       - run: npm -s run test:coverage-check
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ jobs:
           path: coverage
           prefix: test
       - store_test_results:
-          path: coverage
+          path: coverage/lcov.info
   deploy:
     <<: *defaults
     steps:
@@ -67,12 +67,14 @@ workflows:
   build_and_test:
     jobs:
       - setup:
+          context: org-global
           filters:
               branches:
                 ignore: 
                   - /feature*/
                   - /bugfix*/
       - test-unit:
+          context: org-global
           requires:
             - setup
           filters:
@@ -81,6 +83,7 @@ workflows:
                 - /feature*/
                 - /bugfix*/             
       - test-coverage:
+          context: org-global
           requires:
             - setup
           filters:
@@ -89,6 +92,7 @@ workflows:
                 - /feature*/
                 - /bugfix*/
       - deploy:
+          context: org-global
           requires:
             - setup
             - test-unit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,20 +7,6 @@ defaults: &defaults
     - image: circleci/node:6.10.3
 
 jobs:
-  build:
-    docker:
-      - image: circleci/node:6.10.3
-    steps:
-      - checkout
-      # restore npm module dependencies from cache
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-      # setup npm
-      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
-      # publish npm
-      - deploy:
-        name: publish-npm
-        command: npm publish --access public
   setup:
     <<: *defaults
     steps:
@@ -41,10 +27,10 @@ jobs:
       - run: mkdir -p ./test/results
       - run: npm -s run test:xunit > ./test/results/tape.xml
       - store_artifacts:
-          path: ./test/results/
+          path: ./test/results
           prefix: test
       - store_test_results:
-          path: ./test/results/
+          path: ./test/results
   test-coverage:
     <<: *defaults
     steps:
@@ -58,18 +44,20 @@ jobs:
           prefix: test
       - store_test_results:
           path: coverage
-  # test-coverage:
-  #   <<: *defaults
-  #   steps:
-  #     - checkout
-  #     - restore_cache:
-  #         key: dependency-cache-{{ checksum "package.json" }}
-  #     - run: npm -s run test:coverage-check
-  #     - store_artifacts:
-  #         path: coverage
-  #         prefix: test
-  #     - store_test_results:
-  #         path: coverage
+  deploy:
+    docker:
+      - image: circleci/node:6.10.3
+    steps:
+      - checkout
+      # restore npm module dependencies from cache
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
+      # setup npm
+      - run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc
+      # publish npm
+      - deploy:
+        name: publish-npm
+        command: npm publish --access public
 
 workflows:
   version: 2
@@ -97,15 +85,15 @@ workflows:
               ignore: 
                 - /feature*/
                 - /bugfix*/
-      # - build:
-      #   requires:
-      #     - setup
-      #     - test-unit
-      #     - test-coverage
-      #   filters:
-      #       tags:
-      #         only: /v[0-9]+(\.[0-9]+)*/
-      #       branches:
-      #         only: 
-      #           - master
-      #           - develop
+      - deploy:
+        requires:
+          - setup
+          - test-unit
+          - test-coverage
+        # filters:
+        #     tags:
+        #       only: /v[0-9]+(\.[0-9]+)*/
+        #     branches:
+        #       only: 
+        #         - master
+        #         - develop

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-# CircleCI v2 Config test
+# CircleCI v2 Config test sd
 version: 2
 
 defaults: &defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - save_cache:
         key: dependency-cache-{{ checksum "package.json" }}
         paths:
-          - ./node_modules
+          - node_modules
   test-unit:
     docker:
       - image: circleci/node:$NODE_VERSION

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
       - run:
           name: Copy code coverage to SonarQube
           command: |
-            if [ "${CIRCLE_BRANCH}" == "develop-test" ];
+            if [ "${CIRCLE_BRANCH}" == "master" ];
             then
                 echo "Sending lcov.info to SonarQube..."  
                 aws s3 cp coverage/lcov.info $AWS_S3_DIR_SONARQUBE/central-services-auth/lcov.info

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-auth",
-  "version": "0.2.0",
+  "version": "1.1.0-snapshot",
   "description": "Authentication module for central services",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/central-services-auth",
-  "version": "1.1.0-snapshot",
+  "version": "1.1.0-snapshot.1",
   "description": "Authentication module for central services",
   "main": "src/index.js",
   "scripts": {

--- a/test/auth/bearer.test.js
+++ b/test/auth/bearer.test.js
@@ -7,122 +7,122 @@ const UnauthorizedError = require('../../src/auth/unauthorized')
 const InvalidAuthorizationError = require('../../src/auth/invalid-authorization')
 
 const authenticate = (request, reply, options = {}) => {
-  return Bearer.authenticate(options)(request, reply)
+    return Bearer.authenticate(options)(request, reply)
 }
 
 const validRequest = (token = 'token') => {
-  return {
-    headers: {
-      authorization: `Bearer ${token}`
+    return {
+        headers: {
+            authorization: `Bearer ${token}`
+        }
     }
-  }
 }
 
 Test('Bearer scheme', schemeTest => {
-  schemeTest.test('implementation should', implementationTest => {
-    implementationTest.test('return scheme with authenticate method', test => {
-      const result = Bearer.implementation()
+    schemeTest.test('implementation should', implementationTest => {
+        implementationTest.test('return scheme with authenticate method', test => {
+            const result = Bearer.implementation()
 
-      test.ok(result.authenticate)
-      test.equal(typeof result.authenticate, 'function')
-      test.end()
-    })
-    implementationTest.end()
-  })
-
-  schemeTest.test('authenticate should', authenticateTest => {
-    authenticateTest.test('reply with Unauthorized if request authorization header missing', test => {
-      const request = {headers: {}}
-      const reply = (e) => {
-        test.ok(e instanceof UnauthorizedError)
-        test.equal(e.message, 'Missing authorization')
-        test.equal(e.scheme, 'Bearer')
-        test.end()
-      }
-
-      authenticate(request, reply)
+            test.ok(result.authenticate)
+            test.equal(typeof result.authenticate, 'function')
+            test.end()
+        })
+        implementationTest.end()
     })
 
-    authenticateTest.test('reply with InvalidAuthorization if authorization does not have 2 parts', test => {
-      const request = {
-        headers: {
-          authorization: 'Bearer'
-        }
-      }
+    schemeTest.test('authenticate should', authenticateTest => {
+        authenticateTest.test('reply with Unauthorized if request authorization header missing', test => {
+            const request = { headers: {} }
+            const reply = (e) => {
+                test.ok(e instanceof UnauthorizedError)
+                test.equal(e.message, 'Missing authorization')
+                test.equal(e.scheme, 'Bearer')
+                test.end()
+            }
 
-      const reply = (e) => {
-        test.ok(e instanceof InvalidAuthorizationError)
-        test.equal(e.message, 'Bad HTTP authorization header')
-        test.end()
-      }
+            authenticate(request, reply)
+        })
 
-      authenticate(request, reply)
+        authenticateTest.test('reply with InvalidAuthorization if authorization does not have 2 parts', test => {
+            const request = {
+                headers: {
+                    authorization: 'Bearer'
+                }
+            }
+
+            const reply = (e) => {
+                test.ok(e instanceof InvalidAuthorizationError)
+                test.equal(e.message, 'Bad HTTP authorization header')
+                test.end()
+            }
+
+            authenticate(request, reply)
+        })
+
+        authenticateTest.test('reply with InvalidAuthorization if token is empty', test => {
+            const request = {
+                headers: {
+                    authorization: 'Bearer '
+                }
+            }
+
+            const reply = (e) => {
+                test.ok(e instanceof UnauthorizedError)
+                test.equal(e.message, 'Missing token')
+                test.end()
+            }
+
+            authenticate(request, reply)
+        })
+
+        authenticateTest.test('call options validate with token and continue reply with returned credentials', test => {
+            const validateStub = Sinon.stub()
+            const credentials = { user: 'Joe Schmoe' }
+            validateStub.yields(null, true, credentials)
+            const options = { validate: validateStub }
+            const token = 'token'
+            const request = validRequest(token)
+
+            const reply = {
+                continue: (creds) => {
+                    test.ok(validateStub.calledWith(request, token))
+                    test.equal(creds.credentials, credentials)
+                    test.end()
+                }
+            }
+
+            authenticate(request, reply, options)
+        })
+
+        authenticateTest.test('reply with error if validate returns error', test => {
+            let error = new Error()
+            let validateStub = Sinon.stub()
+            validateStub.yields(error)
+            let request = validRequest()
+
+            let reply = (e) => {
+                test.equal(e, error)
+                test.end()
+            }
+
+            authenticate(request, reply, { validate: validateStub })
+        })
+
+        authenticateTest.test('reply with Unauthorized if validate returns invalid', test => {
+            let validateStub = Sinon.stub()
+            validateStub.yields(null, false)
+
+            let reply = (e) => {
+                test.ok(e instanceof UnauthorizedError)
+                test.equal(e.message, 'Invalid token')
+                test.end()
+            }
+
+            authenticate(validRequest(), reply, { validate: validateStub })
+        })
+
+        authenticateTest.end()
     })
 
-    authenticateTest.test('reply with InvalidAuthorization if token is empty', test => {
-      const request = {
-        headers: {
-          authorization: 'Bearer '
-        }
-      }
-
-      const reply = (e) => {
-        test.ok(e instanceof UnauthorizedError)
-        test.equal(e.message, 'Missing token')
-        test.end()
-      }
-
-      authenticate(request, reply)
-    })
-
-    authenticateTest.test('call options validate with token and continue reply with returned credentials', test => {
-      const validateStub = Sinon.stub()
-      const credentials = {user: 'Joe Schmoe'}
-      validateStub.yields(null, true, credentials)
-      const options = {validate: validateStub}
-      const token = 'token'
-      const request = validRequest(token)
-
-      const reply = {
-        continue: (creds) => {
-          test.ok(validateStub.calledWith(request, token))
-          test.equal(creds.credentials, credentials)
-          test.end()
-        }
-      }
-
-      authenticate(request, reply, options)
-    })
-
-    authenticateTest.test('reply with error if validate returns error', test => {
-      let error = new Error()
-      let validateStub = Sinon.stub()
-      validateStub.yields(error)
-      let request = validRequest()
-
-      let reply = (e) => {
-        test.equal(e, error)
-        test.end()
-      }
-
-      authenticate(request, reply, {validate: validateStub})
-    })
-
-    authenticateTest.test('reply with Unauthorized if validate returns invalid', test => {
-      let validateStub = Sinon.stub()
-      validateStub.yields(null, false)
-
-      let reply = (e) => {
-        test.ok(e instanceof UnauthorizedError)
-        test.equal(e.message, 'Invalid token')
-        test.end()
-      }
-
-      authenticate(validRequest(), reply, {validate: validateStub})
-    })
-
-    authenticateTest.end()
-  })
-
-  schemeTest.end()
+    schemeTest.end()
 })

--- a/test/auth/bearer.test.js
+++ b/test/auth/bearer.test.js
@@ -7,122 +7,122 @@ const UnauthorizedError = require('../../src/auth/unauthorized')
 const InvalidAuthorizationError = require('../../src/auth/invalid-authorization')
 
 const authenticate = (request, reply, options = {}) => {
-    return Bearer.authenticate(options)(request, reply)
+  return Bearer.authenticate(options)(request, reply)
 }
 
 const validRequest = (token = 'token') => {
-    return {
-        headers: {
-            authorization: `Bearer ${token}`
-        }
+  return {
+    headers: {
+      authorization: `Bearer ${token}`
     }
+  }
 }
 
 Test('Bearer scheme', schemeTest => {
-    schemeTest.test('implementation should', implementationTest => {
-        implementationTest.test('return scheme with authenticate method', test => {
-            const result = Bearer.implementation()
+  schemeTest.test('implementation should', implementationTest => {
+    implementationTest.test('return scheme with authenticate method', test => {
+      const result = Bearer.implementation()
 
-            test.ok(result.authenticate)
-            test.equal(typeof result.authenticate, 'function')
-            test.end()
-        })
-        implementationTest.end()
+      test.ok(result.authenticate)
+      test.equal(typeof result.authenticate, 'function')
+      test.end()
+    })
+    implementationTest.end()
+  })
+
+  schemeTest.test('authenticate should', authenticateTest => {
+    authenticateTest.test('reply with Unauthorized if request authorization header missing', test => {
+      const request = { headers: {} }
+      const reply = (e) => {
+        test.ok(e instanceof UnauthorizedError)
+        test.equal(e.message, 'Missing authorization')
+        test.equal(e.scheme, 'Bearer')
+        test.end()
+      }
+
+      authenticate(request, reply)
     })
 
-    schemeTest.test('authenticate should', authenticateTest => {
-        authenticateTest.test('reply with Unauthorized if request authorization header missing', test => {
-            const request = { headers: {} }
-            const reply = (e) => {
-                test.ok(e instanceof UnauthorizedError)
-                test.equal(e.message, 'Missing authorization')
-                test.equal(e.scheme, 'Bearer')
-                test.end()
-            }
+    authenticateTest.test('reply with InvalidAuthorization if authorization does not have 2 parts', test => {
+      const request = {
+        headers: {
+          authorization: 'Bearer'
+        }
+      }
 
-            authenticate(request, reply)
-        })
+      const reply = (e) => {
+        test.ok(e instanceof InvalidAuthorizationError)
+        test.equal(e.message, 'Bad HTTP authorization header')
+        test.end()
+      }
 
-        authenticateTest.test('reply with InvalidAuthorization if authorization does not have 2 parts', test => {
-            const request = {
-                headers: {
-                    authorization: 'Bearer'
-                }
-            }
-
-            const reply = (e) => {
-                test.ok(e instanceof InvalidAuthorizationError)
-                test.equal(e.message, 'Bad HTTP authorization header')
-                test.end()
-            }
-
-            authenticate(request, reply)
-        })
-
-        authenticateTest.test('reply with InvalidAuthorization if token is empty', test => {
-            const request = {
-                headers: {
-                    authorization: 'Bearer '
-                }
-            }
-
-            const reply = (e) => {
-                test.ok(e instanceof UnauthorizedError)
-                test.equal(e.message, 'Missing token')
-                test.end()
-            }
-
-            authenticate(request, reply)
-        })
-
-        authenticateTest.test('call options validate with token and continue reply with returned credentials', test => {
-            const validateStub = Sinon.stub()
-            const credentials = { user: 'Joe Schmoe' }
-            validateStub.yields(null, true, credentials)
-            const options = { validate: validateStub }
-            const token = 'token'
-            const request = validRequest(token)
-
-            const reply = {
-                continue: (creds) => {
-                    test.ok(validateStub.calledWith(request, token))
-                    test.equal(creds.credentials, credentials)
-                    test.end()
-                }
-            }
-
-            authenticate(request, reply, options)
-        })
-
-        authenticateTest.test('reply with error if validate returns error', test => {
-            let error = new Error()
-            let validateStub = Sinon.stub()
-            validateStub.yields(error)
-            let request = validRequest()
-
-            let reply = (e) => {
-                test.equal(e, error)
-                test.end()
-            }
-
-            authenticate(request, reply, { validate: validateStub })
-        })
-
-        authenticateTest.test('reply with Unauthorized if validate returns invalid', test => {
-            let validateStub = Sinon.stub()
-            validateStub.yields(null, false)
-
-            let reply = (e) => {
-                test.ok(e instanceof UnauthorizedError)
-                test.equal(e.message, 'Invalid token')
-                test.end()
-            }
-
-            authenticate(validRequest(), reply, { validate: validateStub })
-        })
-
-        authenticateTest.end()
+      authenticate(request, reply)
     })
 
-    schemeTest.end()
+    authenticateTest.test('reply with InvalidAuthorization if token is empty', test => {
+      const request = {
+        headers: {
+          authorization: 'Bearer '
+        }
+      }
+
+      const reply = (e) => {
+        test.ok(e instanceof UnauthorizedError)
+        test.equal(e.message, 'Missing token')
+        test.end()
+      }
+
+      authenticate(request, reply)
+    })
+
+    authenticateTest.test('call options validate with token and continue reply with returned credentials', test => {
+      const validateStub = Sinon.stub()
+      const credentials = { user: 'Joe Schmoe' }
+      validateStub.yields(null, true, credentials)
+      const options = { validate: validateStub }
+      const token = 'token'
+      const request = validRequest(token)
+
+      const reply = {
+        continue: (creds) => {
+          test.ok(validateStub.calledWith(request, token))
+          test.equal(creds.credentials, credentials)
+          test.end()
+        }
+      }
+
+      authenticate(request, reply, options)
+    })
+
+    authenticateTest.test('reply with error if validate returns error', test => {
+      let error = new Error()
+      let validateStub = Sinon.stub()
+      validateStub.yields(error)
+      let request = validRequest()
+
+      let reply = (e) => {
+        test.equal(e, error)
+        test.end()
+      }
+
+      authenticate(request, reply, { validate: validateStub })
+    })
+
+    authenticateTest.test('reply with Unauthorized if validate returns invalid', test => {
+      let validateStub = Sinon.stub()
+      validateStub.yields(null, false)
+
+      let reply = (e) => {
+        test.ok(e instanceof UnauthorizedError)
+        test.equal(e.message, 'Invalid token')
+        test.end()
+      }
+
+      authenticate(validRequest(), reply, { validate: validateStub })
+    })
+
+    authenticateTest.end()
+  })
+
+  schemeTest.end()
 })


### PR DESCRIPTION
Note changes to **test/auth/bearer.test.js** are from the L1P code base that were never merged as part of the following PR: https://github.com/mojaloop/central-services-auth/pull/7. 

These changes have now been included in this PR.